### PR TITLE
feat: view description in new tab

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,9 +6,22 @@ import { TaskProvider } from '@/context/TaskContext';
 export default function RootLayout() {
   return (
     <TaskProvider>
-      <View className="py-14  flex-1 bg-white">
-        <Stack screenOptions={{ headerShown: false }} />
+      <View className="py-14 flex-1 bg-white">
+        <Stack>
+          <Stack.Screen
+            name="index"
+            options={{
+              title: "Tasks", // Title shown for the "home" tab
+            }}
+          />
+          <Stack.Screen
+            name="task/[idx]"
+            options={{
+              title: "Task detail", // Title shown for the "tasks" tab
+            }}
+          />
+        </Stack>
       </View>
     </TaskProvider>
-  )
+  );
 }

--- a/app/task/[idx].tsx
+++ b/app/task/[idx].tsx
@@ -1,0 +1,20 @@
+import { View, Text} from 'react-native'
+import {  useLocalSearchParams } from "expo-router";
+import React from 'react'
+import { useTaskContext } from '@/context/TaskContext';
+import TaskStatusComponent from '@/components/TaskStatusComponent';
+
+const Page = () => {  
+  const {idx}=useLocalSearchParams<{idx?:string}>();
+  const {state} =useTaskContext();
+  const {title,description}=state.tasks[idx];
+  return (
+    <View className="flex-1 gap-y-2 p-4  border-gray-300 border-2 rounded-2xl">
+      <Text className="font-bold text-3xl">{title}</Text>
+      <Text >{description}</Text>
+      <TaskStatusComponent index={idx}/>
+  </View>
+  )
+}
+
+export default Page

--- a/components/Task.tsx
+++ b/components/Task.tsx
@@ -3,21 +3,20 @@ import React from 'react';
 import { useTaskContext } from '@/context/TaskContext';
 import TaskActionNav from './TaskActionNav';
 import TaskStatusComponent from './TaskStatusComponent';
+import { Link } from 'expo-router';
 
 const Task = ({ index }: { index: number }) => {
   const { state } = useTaskContext();
-  const {  title, description } = state.tasks[index];
+  const {  title } = state.tasks[index];
 
 
 
   return (
     <View className="flex gap-y-2 p-4  border-gray-300 border-2 rounded-2xl">
       <View className='flex-row justify-between items-center'>
-        <Text className="font-bold">{title}</Text>
+        <Link href={{pathname:'/task/[idx]', params:{idx:index}}} className="font-bold">{title}</Link>
         <TaskActionNav index={index}/>
       </View>
-
-      <Text>{description}</Text>
 
       <TaskStatusComponent index={index}/>
     </View>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".expo/types/**/*.ts",
-    "expo-env.d.ts",
+    "node_modules/expo-env.d.ts",
     "node_modules/nativewind-env.d.ts",
     "nativewind-env.d.ts"
   ]


### PR DESCRIPTION
- use Stack to pop back to Lists page and push to List detail page
- Cusomize tab name
- pass Idx and integrate with ListContext to List detail page to retrieve correct List detail